### PR TITLE
Implement unavailable hours API and frontend

### DIFF
--- a/src/main/java/com/iZoneHub/demo/controller/BookingApiController.java
+++ b/src/main/java/com/iZoneHub/demo/controller/BookingApiController.java
@@ -7,8 +7,11 @@ import com.iZoneHub.demo.service.BookingService;
 import jakarta.servlet.http.HttpSession; // 確保已引入
 import org.springframework.http.HttpStatus; // 確保已引入
 import org.springframework.http.ResponseEntity;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 // ... 其他 import ...
 
@@ -22,7 +25,12 @@ public class BookingApiController {
         this.bookingService = bookingService;
     }
 
-    // ... 其他方法，例如 getUnavailableSlots ...
+    @GetMapping("/unavailable")
+    public ResponseEntity<List<Integer>> getUnavailableHours(
+            @RequestParam Long roomId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ResponseEntity.ok(bookingService.getUnavailableHours(roomId, date));
+    }
 
     @PostMapping
     public ResponseEntity<?> createBooking(@RequestBody BookingRequest request, HttpSession session) {

--- a/src/main/resources/templates/booking.html
+++ b/src/main/resources/templates/booking.html
@@ -89,6 +89,27 @@
     const roomPrice = parseFloat(document.getElementById('roomPrice')?.value || 0);
     const roomId = document.getElementById('roomId')?.value;
 
+    async function updateUnavailable(date) {
+      if (!date || !roomId) return;
+      try {
+        const resp = await fetch(`/api/bookings/unavailable?roomId=${roomId}&date=${date}`);
+        if (!resp.ok) return;
+        const hours = await resp.json();
+        [startHourSelect, endHourSelect].forEach(select => {
+          Array.from(select.options).forEach(opt => {
+            opt.disabled = false;
+            opt.classList.remove('text-muted');
+            if (hours.includes(parseInt(opt.value))) {
+              opt.disabled = true;
+              opt.classList.add('text-muted');
+            }
+          });
+        });
+      } catch (e) {
+        console.error('Failed to fetch unavailable hours', e);
+      }
+    }
+
     // 1. 產生 0-23 點的下拉選單
     function populateHourOptions(selectElement) {
       for (let i = 0; i < 24; i++) {
@@ -101,6 +122,9 @@
     }
     populateHourOptions(startHourSelect);
     populateHourOptions(endHourSelect);
+    if (startDateInput.value) {
+      updateUnavailable(startDateInput.value);
+    }
 
     // 2. 計算並顯示預估價格
     function calculatePrice() {
@@ -128,6 +152,9 @@
     [startDateInput, startHourSelect, endDateInput, endHourSelect].forEach(el => {
       el.addEventListener('change', calculatePrice);
     });
+
+    startDateInput.addEventListener('change', e => updateUnavailable(e.target.value));
+    endDateInput.addEventListener('change', e => updateUnavailable(e.target.value));
 
     // 4. 處理預約表單提交
     if (bookingForm) {

--- a/src/test/java/com/iZoneHub/demo/controller/BookingApiControllerTest.java
+++ b/src/test/java/com/iZoneHub/demo/controller/BookingApiControllerTest.java
@@ -1,0 +1,51 @@
+package com.iZoneHub.demo.controller;
+
+import com.iZoneHub.demo.service.BookingService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BookingApiController.class)
+@Import(BookingApiControllerTest.TestConfig.class)
+public class BookingApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BookingService bookingService;
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public BookingService bookingService() {
+            return Mockito.mock(BookingService.class);
+        }
+    }
+
+    @Test
+    void getUnavailableHoursEndpointReturnsHours() throws Exception {
+        when(bookingService.getUnavailableHours(1L, LocalDate.parse("2024-05-01")))
+                .thenReturn(List.of(9, 10));
+
+        mockMvc.perform(get("/api/bookings/unavailable")
+                        .param("roomId", "1")
+                        .param("date", "2024-05-01"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[9,10]"));
+    }
+}
+

--- a/src/test/java/com/iZoneHub/demo/service/BookingServiceTest.java
+++ b/src/test/java/com/iZoneHub/demo/service/BookingServiceTest.java
@@ -1,0 +1,56 @@
+package com.iZoneHub.demo.service;
+
+import com.iZoneHub.demo.model.Booking;
+import com.iZoneHub.demo.repository.BookingRepository;
+import com.iZoneHub.demo.repository.RoomRepository;
+import com.iZoneHub.demo.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+public class BookingServiceTest {
+
+    @Mock
+    BookingRepository bookingRepository;
+    @Mock
+    RoomRepository roomRepository;
+    @Mock
+    UserRepository userRepository;
+
+    BookingService bookingService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        bookingService = new BookingService(bookingRepository, roomRepository, userRepository);
+    }
+
+    @Test
+    void getUnavailableHoursReturnsSortedHours() {
+        LocalDate date = LocalDate.of(2024, 5, 1);
+        ZoneId zone = ZoneId.systemDefault();
+        Booking b1 = new Booking();
+        b1.setStartTime(date.atTime(13,30).atZone(zone).toInstant());
+        b1.setEndTime(date.atTime(15,0).atZone(zone).toInstant());
+        Booking b2 = new Booking();
+        b2.setStartTime(date.atTime(9,0).atZone(zone).toInstant());
+        b2.setEndTime(date.atTime(10,0).atZone(zone).toInstant());
+
+        when(bookingRepository.findOverlappingBookings(eq(1L), any(), any()))
+                .thenReturn(List.of(b1, b2));
+
+        List<Integer> hours = bookingService.getUnavailableHours(1L, date);
+        assertEquals(List.of(9,13,14), hours);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `getUnavailableHours` in `BookingService`
- add `/api/bookings/unavailable` endpoint
- update booking page script to disable unavailable hours
- add unit tests for new service logic and controller endpoint
- remove outdated comment

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68884e0773b0832da51e77d77ddb7891