### PR TITLE
Fix booking end time availability

### DIFF
--- a/src/main/resources/templates/booking.html
+++ b/src/main/resources/templates/booking.html
@@ -95,15 +95,26 @@
         const resp = await fetch(`/api/bookings/unavailable?roomId=${roomId}&date=${date}`);
         if (!resp.ok) return;
         const hours = await resp.json();
-        [startHourSelect, endHourSelect].forEach(select => {
-          Array.from(select.options).forEach(opt => {
-            opt.disabled = false;
-            opt.classList.remove('text-muted');
-            if (hours.includes(parseInt(opt.value))) {
-              opt.disabled = true;
-              opt.classList.add('text-muted');
-            }
-          });
+
+        // start 時間直接禁用回傳的時段
+        Array.from(startHourSelect.options).forEach(opt => {
+          opt.disabled = false;
+          opt.classList.remove('text-muted');
+          if (hours.includes(parseInt(opt.value))) {
+            opt.disabled = true;
+            opt.classList.add('text-muted');
+          }
+        });
+
+        // end 時間需禁用與預約結束重疊的時段 (回傳時段 + 1 小時)
+        const endHours = hours.map(h => h + 1).filter(h => h <= 23);
+        Array.from(endHourSelect.options).forEach(opt => {
+          opt.disabled = false;
+          opt.classList.remove('text-muted');
+          if (endHours.includes(parseInt(opt.value))) {
+            opt.disabled = true;
+            opt.classList.add('text-muted');
+          }
         });
       } catch (e) {
         console.error('Failed to fetch unavailable hours', e);


### PR DESCRIPTION
## Summary
- adjust booking page time selection logic to allow ending a booking at an already booked start time

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688855af9278832db9cbabbef516c0f1